### PR TITLE
create TUN device in startup script if specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ docker run --privileged  -d \
 |`VPN_TYPE`| Yes | WireGuard or OpenVPN? (wireguard/openvpn)|`VPN_TYPE=wireguard`|`openvpn`|
 |`VPN_USERNAME`| No | If username and password provided, configures ovpn file automatically |`VPN_USERNAME=ad8f64c02a2de`||
 |`VPN_PASSWORD`| No | If username and password provided, configures ovpn file automatically |`VPN_PASSWORD=ac98df79ed7fb`||
+|`CREATE_TUN_DEVICE`| No | Creates /dev/net/tun device inside the container, mitigates the need mount the device from the host |CREATE_TUN_DEVICE=true||
 |`WEBUI_PASSWORD`| Yes | The password used to protect/access Jackett's web interface |`WEBUI_PASSWORD=RJayoLnKPjeyHbo-_ziH`||
 |`LAN_NETWORK`| Yes (atleast one) | Comma delimited local Network's with CIDR notation |`LAN_NETWORK=192.168.0.0/24,10.10.0.0/24`||
 |`NAME_SERVERS`| No | Comma delimited name servers |`NAME_SERVERS=1.1.1.1,1.0.0.1`|`1.1.1.1,1.0.0.1`|

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -13,6 +13,14 @@ if [[ ! -z "${check_network}" ]]; then
 	exit 1
 fi
 
+# If create_tun_device is set, create /dev/net/tun
+if [[ "${CREATE_TUN_DEVICE,,}" == "true" ]]; then
+	echo "Creating TUN device /dev/net/tun"
+	mkdir -p /dev/net
+	mknod /dev/net/tun c 10 200
+	chmod 0666 /dev/net/tun
+fi
+
 export VPN_ENABLED=$(echo "${VPN_ENABLED,,}" | sed -e 's~^[ \t]*~~;s~[ \t]*$~~')
 if [[ ! -z "${VPN_ENABLED}" ]]; then
 	echo "[INFO] VPN_ENABLED defined as '${VPN_ENABLED}'" | ts '%Y-%m-%d %H:%M:%.S'


### PR DESCRIPTION
lifted from https://github.com/haugene/docker-transmission-openvpn/

with this, you don't need to run the container in privileged mode or mount the tun device from the host - you just need to add the NET_ADMIN capability:

ex:
```
  jackett:
    cap_add:
      - NET_ADMIN
    image: dyonr/jackettvpn:latest
    container_name: jackett
```