### PR TITLE
Updated libicu to libicu67

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.li
     iptables \
     jq \
     kmod \
-    libicu63 \
+    libicu67 \
     moreutils \
     net-tools \
     openresolv \


### PR DESCRIPTION
libicu63 is not available anymore, resulting in failure of creating the Docker. This pull requests installs a libicu to a version that is available